### PR TITLE
Change Docker image to support Ruby 3.2.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:3.1.2-alpine
+FROM ruby:3.2.2-alpine
 
 RUN apk add --update build-base git
 


### PR DESCRIPTION
📢 **Disclamer**: I am not very experienced with GitHub Actions and Docker. I am happy to change anything on this PR, or to close it, if this solution is not the right one for the problem we are facing.

# Type of PR (feature, enhancement, bug fix, etc.)

## Description

When using Ruby 3.1, some standard rules cannot be applied, such as `Style/ArgumentsForwarding` which changes `*args` into `*`.

The current (v0.0.4) version is using `ruby:3.1.2-alpine`, which makes the Action run on Ruby 3.1.2 and doesn't allow to run it on a code base following the latest Standard rules for Ruby 3.2.2.

This changes from `ruby:3.1.2-alpine` to `ruby:3.2.2-alpine` to allow this.

## Why should this be added

The current version doesn't allow to run the Action against a code base following the Ruby 3.2.2 Standard rules.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] Actions are passing
